### PR TITLE
Update _partector_blueprint.py - Wrong version, delete

### DIFF
--- a/src/naneos/partector/blueprints/_partector_blueprint.py
+++ b/src/naneos/partector/blueprints/_partector_blueprint.py
@@ -187,7 +187,8 @@ class PartectorBluePrint(Thread, PartectorDefaults, ABC):
 
         try:
             if self._ser.is_open:
-                self._serial_reading_routine()
+                while not self.thread_event.is_set():
+                    self._serial_reading_routine()
         except Exception as e:
             logger.warning(f"SN{self._sn} Exception occured during threaded serial reading: {e}")
 


### PR DESCRIPTION
**Problem:**
P2 USB readout works well for:
- Linux with all frequencies
- Windows with 1Hz and 10Hz But it drops ~30-40% of the lines on Windows with 100Hz. 

**After the patch:**
Dropped (almost) no lines on Windows for 1, 10 and 100Hz

**Currently tested on:**
Windows 10 Home, 
Python 3.11.9, 
naneos-devices Version: 1.0.61

**--> Might need more testing...**