### PR TITLE
Update _partector_blueprint.py - Reliable 100Hz readout on Windows

### DIFF
--- a/src/naneos/partector/blueprints/_partector_blueprint.py
+++ b/src/naneos/partector/blueprints/_partector_blueprint.py
@@ -68,7 +68,7 @@ class PartectorBluePrint(Thread, PartectorDefaults, ABC):
         checker_thread = Thread(target=self._checker_thread)
         checker_thread.start()
 
-        while not self.thread_event.wait(0.001):
+        while not self.thread_event.is_set():
             self._run()
 
         checker_thread.join()


### PR DESCRIPTION
**Problem:**
P2 USB readout works well for:
- Linux with all frequencies
- Windows with 1Hz and 10Hz But it drops ~30-40% of the lines on Windows with 100Hz. 

**After the patch:**
Dropped (almost) no lines on Windows for 1, 10 and 100Hz

**Currently tested on:**
Windows 10 Home, 
Python 3.11.9, 
naneos-devices Version: 1.0.61

**--> Might need more testing...**